### PR TITLE
Fully implemented my.cnf with green tests

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -16,6 +16,7 @@ my $build = Module::Build->new(
 		'Moose'            => 0,
 		'MooseX::Object::Pluggable' => 0,
 		'Params::Validate' => 0,
+		'Data::Structure::Util' => 0,
 		'DBI'              => 0,
 		'DBD::mysql'       => 0,
 		'Term::ReadLine::Zoid' => 0,

--- a/META.json
+++ b/META.json
@@ -27,6 +27,7 @@
       "runtime" : {
          "requires" : {
             "Config::Any" : "0",
+						"Data::Structure::Util" : "0",
             "DBD::mysql" : "0",
             "DBI" : "0",
             "Data::Dumper" : "0",

--- a/META.yml
+++ b/META.yml
@@ -73,6 +73,7 @@ provides:
     version: 0
 requires:
   Config::Any: 0
+  Data::Structure::Util: 0
   DBD::mysql: 0
   DBI: 0
   Data::Dumper: 0

--- a/lib/App/AltSQL.pm
+++ b/lib/App/AltSQL.pm
@@ -215,6 +215,7 @@ sub BUILD {
 		}
 	}
 
+	$self->model->find_and_read_configs();
 	$self->model->db_connect();
 }
 


### PR DESCRIPTION
Fully implemented the my.cnf support with passing tests.

Support for key-only configuration fields, boolean fields (true/false map to 1/0),
and some basic aliasing of fields. Honor [mysql] and [client] sections
in my.cnf. No more test polution from automatic reading of ~/.my.cnf
during test suite run.
