### PR TITLE
^Z works for backgrounding altsql

### DIFF
--- a/lib/App/AltSQL/Term.pm
+++ b/lib/App/AltSQL/Term.pm
@@ -60,9 +60,7 @@ sub _build_term {
 	};
 
 	$term->bindkey('^Z', sub {
-		# The Term::ReadLine::Zoid uses Term::ReadKey in 'raw' mode which disables all signals
-		# If we can find a way to background ourselves at this point, that's the only option that I can see
-		$self->log_info("Backgrounding is not currently possible");
+		kill 20, $$; # send ourselves SIGTSTP
 	});
 
 	$term->bindkey('^D', sub {


### PR DESCRIPTION
On ^Z, issue "kill 20, $$". This tells the process to move itself into the background.

20 is the POSIX-compliant value for SIGTSTP, which is the message for a process to move itself into the background (or perhaps for the kernel to do so). This change might make the application behave strangely on non-POSIX systems.

See http://en.wikipedia.org/wiki/Unix_signal#List_of_signals
