### PR TITLE
Remove the binding to ^D

### DIFF
--- a/lib/App/AltSQL/Term.pm
+++ b/lib/App/AltSQL/Term.pm
@@ -63,11 +63,6 @@ sub _build_term {
 		kill 20, $$; # send ourselves SIGTSTP
 	});
 
-	$term->bindkey('^D', sub {
-		print "\n";
-		$self->app->shutdown();
-	});
-
 	$term->bindkey('return', sub { $self->return_key });
 
 	$self->read_history();


### PR DESCRIPTION
I keep exiting by mistake because decades of readline use (Emacs, bash, &c.) have conditioned me to type C-d to delete a character. This is another version of the C-c problem that altsql solved. I found I could just remove the binding here and C-d still exits when there's no text to delete.

From the readline man page

      delete-char (C-d)
              Delete the character at point.  If point is at the beginning  of
              the  line,  there  are  no  characters in the line, and the last
              character typed was not bound to delete-char, then return EOF.

So C-d deletes when I need it to and exits altsql on a blank line. Everybody wins!
