### PR TITLE
Improvements in kwalitee

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -29,6 +29,7 @@ my $build = Module::Build->new(
 		'Config::Any'      => 0,
 		'JSON'             => 0,
  		'YAML'             => 0,
+		'perl'             => '5.8.0',
 	},
 	suggests => {
 		'DateTime'         => 0,

--- a/lib/App/AltSQL/Model/MySQL.pm
+++ b/lib/App/AltSQL/Model/MySQL.pm
@@ -363,14 +363,10 @@ my %prompt_substitutions = (
 	P    => '%t{%p}',
 );
 
-=cut
-
-Take a .my.cnf prompt format and convert it into Term escape options
-
-Reference:
-http://www.thegeekstuff.com/2010/02/mysql_ps1-6-examples-to-make-your-mysql-prompt-like-angelina-jolie/
-
-=cut
+# Take a .my.cnf prompt format and convert it into Term escape options
+#
+# Reference:
+# http://www.thegeekstuff.com/2010/02/mysql_ps1-6-examples-to-make-your-mysql-prompt-like-angelina-jolie/
 
 sub parse_prompt {
 	my $self = shift;


### PR DESCRIPTION
There were 2 significant CPANTS kwalitee fails for version 0.05: [no_pod_errors and meta_yml_declares_perl_version](http://cpants.cpanauthors.org/dist/App-AltSQL-0.05). This simple PR should fix both of them.

I've assumed that the malformed POD in lib/App/AltSQL/Model/MySQL.pm was just supposed to be a multi-line comment and so have rewritten it as such. Do get back to me if this was actually supposed to appear in the POD.