### PR TITLE
Call model_class as hash key not method

### DIFF
--- a/t/lib/My/Common.pm
+++ b/t/lib/My/Common.pm
@@ -31,7 +31,7 @@ sub bootstrap_db ($) {
 	my $dbh = $app->model->dbh;
 
 	if (! $ENV{SKIP_BOOTSTRAP}) {
-		if ($app->args->model_class eq 'App::AltSQL::Model::MySQL') {
+		if ($app->args->{model_class} eq 'App::AltSQL::Model::MySQL') {
 			$dbh->do("drop database if exists $db_config{database}");
 			$dbh->do("create database $db_config{database}");
 


### PR DESCRIPTION
Test runner failed as $app->args->model_class was incorrect, it was/is
not a blessed reference so fails. So we change it here.

This is part of the CPAN Pull request challenge.
This change makes the t/004_runtime_mysql.t work when MYSQL_TESTS=1
